### PR TITLE
PostCSS 8.1 compatability

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-let postcss = require('postcss')
 const sortCSSmq = require('sort-css-media-queries')
 
 module.exports = (opts = {}) => {
@@ -23,13 +22,14 @@ module.exports = (opts = {}) => {
       }
       return {
         AtRule: {
-          media: atRule => {
+          media: (atRule, { AtRule }) => {
             let query = atRule.params
 
             if (!atRules[query]) {
-              atRules[query] = postcss.atRule({
+              atRules[query] = new AtRule({
                 name: atRule.name,
-                params: atRule.params
+                params: atRule.params,
+                source: atRule.source
               })
             }
 
@@ -40,7 +40,7 @@ module.exports = (opts = {}) => {
             atRule.remove()
           }
         },
-        RootExit (root) {
+        OnceExit (root) {
           sortAtRules(Object.keys(atRules), opts.sort).forEach(query => {
             root.append(atRules[query])
           })

--- a/package-lock.json
+++ b/package-lock.json
@@ -6419,9 +6419,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.0.9.tgz",
-      "integrity": "sha512-9Ikq03Hvb/L6dgnOtNOUbcgg9Rsff5uKrI1TyNTQ2ALpa6psZk1Ar3/Hhxv2Q0rECRGDxtcMUTZIQglXozlrDQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.1.0.tgz",
+      "integrity": "sha512-d3RppIo1DI66oHxA1vdckr5qciQbMIrHvyzuvp2cLJHOLwJHg7X9ncrfw2Ri6Sgiwv/GoXtOwEHJ9E9VSRxXWQ==",
       "dev": true,
       "requires": {
         "colorette": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     "jest-ci": "^0.1.1",
     "jest-cli": "^26.4.2",
     "lint-staged": "^10.4.0",
-    "postcss": "^8.0.2"
+    "postcss": "^8.1.0"
   },
   "peerDependencies": {
-    "postcss": "^8.0.9"
+    "postcss": "^8.1.0"
   },
   "husky": {
     "hooks": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3367,10 +3367,10 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
-postcss@^8.0.2:
-  version "8.0.9"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.0.9.tgz#d112fc1e8bbed550657901550fa736ae3dd25ec5"
-  integrity sha512-9Ikq03Hvb/L6dgnOtNOUbcgg9Rsff5uKrI1TyNTQ2ALpa6psZk1Ar3/Hhxv2Q0rECRGDxtcMUTZIQglXozlrDQ==
+postcss@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.1.0.tgz#1be330c7f6971d49726059b9f51785f45273fa70"
+  integrity sha512-d3RppIo1DI66oHxA1vdckr5qciQbMIrHvyzuvp2cLJHOLwJHg7X9ncrfw2Ri6Sgiwv/GoXtOwEHJ9E9VSRxXWQ==
   dependencies:
     colorette "^1.2.1"
     line-column "^1.0.2"


### PR DESCRIPTION
1. Use `OnceExit` instead of `RootExit` (since `RootExit` will be called again on new at-rules)
2. Do not import `postcss`
3. Fix source maps