### PR TITLE
Recursive sort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 node_modules/
 npm-debug.log
 yarn-error.log

--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,7 @@ yarn.lock
 .editorconfig
 .gitattributes
 .github
+.vscode
 index.test.js
 
 CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -249,6 +249,18 @@ postcss([
 ]).process(css);
 ```
 
+### Recursive
+
+Sort nested media queries recursivey
+
+```js
+postcss([
+  sortMediaQueries({
+    recursive: true,
+  })
+]).process(css);
+```
+
 ---
 
 ## Changelog

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ module.exports = (opts = {}) => {
         if (!atRulesKeys.length) return;
 
         sortAtRules(atRulesKeys).forEach(query => {
-          if (recursive) recursivelySort(atRules[query]);
+          if (!onlyTopLevel && recursive) recursivelySort(atRules[query]);
 
           localRoot.append(atRules[query]);
         });

--- a/index.js
+++ b/index.js
@@ -1,74 +1,107 @@
-function sortAtRules(queries, sort, sortCSSmq) {
-  if (typeof sort !== 'function') {
-    sort = sort === 'desktop-first' ? sortCSSmq.desktopFirst : sortCSSmq
-  }
+// @ts-check
 
-  return queries.sort(sort)
-}
+/**
+ * @typedef {import('postcss/lib/postcss').Plugin} Plugin
+ * @typedef {import('postcss/lib/postcss').Root} Root
+ * @typedef {import('postcss/lib/postcss').AtRule} AtRule
+ * @typedef {import('sort-css-media-queries/lib')} SortCSSmq
+ */
 
+/**
+ * Sort function declaration
+ * @callback sortFn
+ * @param {string} A - previous
+ * @param {string} B - next
+ * @returns {number}
+ */
+
+/**
+ * @typedef {object} sortCSSMediaQueriesOptions
+ * @property {boolean=} unitlessMqAlwaysFirst unitless media queries first. Defaults to false
+ */
+
+/**
+ * @typedef {object} pluginOptions
+ * @property {'mobile-first'|'desktop-first'|sortFn=} sort Sort strategy.
+ * @property {false|sortCSSMediaQueriesOptions=} configuration sort-css-media-queries options.
+ * @property {boolean=} onlyTopLevel Whether to sort the top level only or not. Defaults to false.
+ * @property {boolean=} recursive Whether to sort recursively or not. Defaults to false.
+ * @property {string|RegExp=} pattern string or regex pattern to math media querie like atRules. Defaults to 'media'.
+ */
+
+/**
+ * Plugin constructor
+ * @param {pluginOptions} opts - plugin options
+ * @returns {Plugin} - plugin object
+ */
 module.exports = (opts = {}) => {
-
-  opts = Object.assign(
+  const {sort, configuration, onlyTopLevel, pattern, recursive} = Object.assign(
     {
       sort: 'mobile-first',
-      configuration: false,
-      onlyTopLevel: false,
+      pattern: 'media',
     },
     opts
   )
 
   const createSort = require('sort-css-media-queries/lib/create-sort');
-  const sortCSSmq = opts.configuration ? createSort(opts.configuration) : require('sort-css-media-queries');
+  /** @type {SortCSSmq} */
+  const sortCSSmq = configuration ? createSort(configuration) : require('sort-css-media-queries');
 
   return {
     postcssPlugin: 'postcss-sort-media-queries',
-    OnceExit (root, { AtRule }) {
-
-      let atRules = [];
-
-      root.walkAtRules('media', atRule => {
-        if (opts.onlyTopLevel && atRule.parent.type === 'root') {
-          let query = atRule.params
-
-          if (!atRules[query]) {
-            atRules[query] = new AtRule({
-              name: atRule.name,
-              params: atRule.params,
-              source: atRule.source
-            })
-          }
-
-          atRule.nodes.forEach(node => {
-            atRules[query].append(node.clone())
-          })
-
-          atRule.remove()
+    OnceExit (root, {AtRule}) {
+      /**
+       * Sort query strings
+       * @param {string[]} queries - Query string array
+       */
+      function sortAtRules(queries) {
+        if (typeof sort !== 'function') {
+          return queries.sort(sort === 'desktop-first' ? sortCSSmq.desktopFirst : sortCSSmq)
         }
 
-        if (!opts.onlyTopLevel) {
-          let query = atRule.params
-
-          if (!atRules[query]) {
-            atRules[query] = new AtRule({
-              name: atRule.name,
-              params: atRule.params,
-              source: atRule.source
-            })
-          }
-
-          atRule.nodes.forEach(node => {
-            atRules[query].append(node.clone())
-          })
-
-          atRule.remove()
-        }
-      })
-
-      if (atRules) {
-        sortAtRules(Object.keys(atRules), opts.sort, sortCSSmq).forEach(query => {
-          root.append(atRules[query])
-        })
+        return queries.sort(sort)
       }
+
+      /**
+       * Recursively sort CSS media queries
+       * @template {AtRule|Root} T
+       * @param {T} localRoot - Root or atRule instance
+       */
+      function recursivelySort(localRoot){
+        /** @type {{[key: string]: AtRule}} */
+        const atRules = {};
+
+        localRoot.walkAtRules(pattern, atRule => {
+          const atRuleIndex = localRoot.index(atRule)
+          const query = atRule.params;
+
+          if (atRuleIndex === -1 || onlyTopLevel && atRule.parent && atRule.parent.type !== 'root') return;
+
+          if (!atRules[query]) {
+            atRules[query] = new AtRule({
+              name: atRule.name,
+              params: atRule.params,
+              source: atRule.source
+            })
+          }
+
+          atRules[query].append(atRule.nodes);
+
+          atRule.remove();
+        })
+
+        const atRulesKeys = Object.keys(atRules);
+
+        if (!atRulesKeys.length) return;
+
+        sortAtRules(atRulesKeys).forEach(query => {
+          if (recursive) recursivelySort(atRules[query]);
+
+          localRoot.append(atRules[query]);
+        });
+      }
+
+      recursivelySort(root);
     }
   }
 }

--- a/index.test.js
+++ b/index.test.js
@@ -1,154 +1,105 @@
-let fs = require('fs')
-let postcss = require('postcss')
-let nested = require('postcss-nested')
-let mediaMinMax = require('postcss-media-minmax')
-let autoprefixer = require('autoprefixer')
-let flexbugsFixes = require('postcss-flexbugs-fixes')
+// @ts-check
 
-let plugin = require('./')
+const fs = require('fs')
+const postcss = require('postcss')
+const nested = require('postcss-nested')
+const mediaMinMax = require('postcss-media-minmax')
+const autoprefixer = require('autoprefixer')
+const flexbugsFixes = require('postcss-flexbugs-fixes')
 
-async function run (input, output, opts) {
-  let result = await postcss([plugin(opts)]).process(input, { from: undefined })
-  expect(result.css).toEqual(output)
-  expect(result.warnings()).toHaveLength(0)
-}
+const plugin = require('./')
 
-async function nestedRun (input, output, opts) {
-  let result = await postcss([nested, plugin(opts)]).process(input, { from: undefined })
-  expect(result.css).toEqual(output)
-  expect(result.warnings()).toHaveLength(0)
-}
+async function run (inputFileName, outputFileName, opts = {}, plugins = []) {
+  const input = fs.readFileSync(`./test/${inputFileName}.css`, 'utf8');
+  const output = fs.readFileSync(`./test/${outputFileName}.css`, 'utf8');
+  const result = await postcss([...plugins, plugin(opts)]).process(input, { from: undefined });
 
-async function mediaMinmaxBeforeNestedRun (input, output, opts) {
-  let result = await postcss([autoprefixer, flexbugsFixes, mediaMinMax, nested, plugin(opts)]).process(input, { from: undefined })
-  expect(result.css).toEqual(output)
-  expect(result.warnings()).toHaveLength(0)
-}
-
-async function mediaMinmaxAfterNestedRun (input, output, opts) {
-  let result = await postcss([autoprefixer, flexbugsFixes, nested, mediaMinMax, plugin(opts)]).process(input, { from: undefined })
-  expect(result.css).toEqual(output)
-  expect(result.warnings()).toHaveLength(0)
+  expect(result.css).toEqual(output);
+  expect(result.warnings()).toHaveLength(0);
 }
 
 it('[mf] simple #1', async () => {
-  let input = fs.readFileSync('./test/s1-mobile.in.css', 'utf8')
-  let output = fs.readFileSync('./test/s1-mobile.out.css', 'utf8')
-  await run(input, output, { sort: 'mobile-first' })
-})
+  await run('s1-mobile.in', 's1-mobile.out', { sort: 'mobile-first' });
+});
 
 it('[df] simple #1', async () => {
-  let input = fs.readFileSync('./test/s1-desktop.in.css', 'utf8')
-  let output = fs.readFileSync('./test/s1-desktop.out.css', 'utf8')
-  await run(input, output, { sort: 'desktop-first' })
-})
+  await run('s1-desktop.in', 's1-desktop.out', { sort: 'desktop-first' });
+});
 
 it('[mf] simple #2', async () => {
-  let input = fs.readFileSync('./test/s2-mobile.in.css', 'utf8')
-  let output = fs.readFileSync('./test/s2-mobile.out.css', 'utf8')
-  await run(input, output, { sort: 'mobile-first' })
-})
+  await run('s2-mobile.in', 's2-mobile.out', { sort: 'mobile-first' });
+});
 
 it('[df] simple #2', async () => {
-  let input = fs.readFileSync('./test/s2-desktop.in.css', 'utf8')
-  let output = fs.readFileSync('./test/s2-desktop.out.css', 'utf8')
-  await run(input, output, { sort: 'desktop-first' })
-})
+  await run('s2-desktop.in', 's2-desktop.out', { sort: 'desktop-first' });
+});
 
 it('[mf] without dimension #1', async () => {
-  let input = fs.readFileSync('./test/wd1-mobile.in.css', 'utf8')
-  let output = fs.readFileSync('./test/wd1-mobile.out.css', 'utf8')
-  await run(input, output, { sort: 'mobile-first' })
-})
+  await run('wd1-mobile.in', 'wd1-mobile.out', { sort: 'mobile-first' });
+});
 
 it('[df] without dimension #1', async () => {
-  let input = fs.readFileSync('./test/wd1-desktop.in.css', 'utf8')
-  let output = fs.readFileSync('./test/wd1-desktop.out.css', 'utf8')
-  await run(input, output, { sort: 'desktop-first' })
-})
+  await run('wd1-desktop.in', 'wd1-desktop.out', { sort: 'desktop-first' });
+});
 
 it('[mf] mixed #1', async () => {
-  let input = fs.readFileSync('./test/mixed-mobile.in.css', 'utf8')
-  let output = fs.readFileSync('./test/mixed-mobile.out.css', 'utf8')
-  await run(input, output, { sort: 'mobile-first' })
-})
+  await run('mixed-mobile.in', 'mixed-mobile.out', { sort: 'mobile-first' });
+});
 
 it('[df] mixed #1', async () => {
-  let input = fs.readFileSync('./test/mixed-desktop.in.css', 'utf8')
-  let output = fs.readFileSync('./test/mixed-desktop.out.css', 'utf8')
-  await run(input, output, { sort: 'desktop-first' })
-})
+  await run('mixed-desktop.in', 'mixed-desktop.out', { sort: 'desktop-first' });
+});
 
 it('[mf] configuration(mixed #1): unitlessMqAlwaysFirst: FALSE', async () => {
-  let input = fs.readFileSync('./test/configuration/false-mixed-mobile.in.css', 'utf8')
-  let output = fs.readFileSync('./test/configuration/false-mixed-mobile.out.css', 'utf8')
-
-  let options = {
+  const options = {
     configuration: {
       unitlessMqAlwaysFirst: false,
     }
   }
-  await run(input, output, options)
-})
+  await run('configuration/false-mixed-mobile.in', 'configuration/false-mixed-mobile.out', options)
+});
 
 it('[mf] configuration(mixed #1): unitlessMqAlwaysFirst: TRUE', async () => {
-  let input = fs.readFileSync('./test/configuration/true-mixed-mobile.in.css', 'utf8')
-  let output = fs.readFileSync('./test/configuration/true-mixed-mobile.out.css', 'utf8')
-
-  let options = {
+  const options = {
     configuration: {
       unitlessMqAlwaysFirst: true,
     }
   }
-  await run(input, output, options)
-})
+  await run('configuration/true-mixed-mobile.in', 'configuration/true-mixed-mobile.out', options)
+});
 
 it('[df] configuration(mixed #2): unitlessMqAlwaysFirst: FALSE', async () => {
-  let input = fs.readFileSync('./test/configuration/false-mixed-desktop.in.css', 'utf8')
-  let output = fs.readFileSync('./test/configuration/false-mixed-desktop.out.css', 'utf8')
-
-  let options = {
+  const options = {
     sort: 'desktop-first',
     configuration: {
       unitlessMqAlwaysFirst: false,
     }
   }
-  await run(input, output, options)
-})
+  await run('configuration/false-mixed-desktop.in', 'configuration/false-mixed-desktop.out', options)
+});
 
 it('[df] configuration(mixed #2): unitlessMqAlwaysFirst: TRUE', async () => {
-  let input = fs.readFileSync('./test/configuration/true-mixed-desktop.in.css', 'utf8')
-  let output = fs.readFileSync('./test/configuration/true-mixed-desktop.out.css', 'utf8')
-
-  let options = {
+  const options = {
     sort: 'desktop-first',
     configuration: {
       unitlessMqAlwaysFirst: true,
     }
   }
-  await run(input, output, options)
-})
+  await run('configuration/true-mixed-desktop.in', 'configuration/true-mixed-desktop.out', options)
+});
 
 it('postcss nested', async () => {
-  let input = fs.readFileSync('./test/postcss.nested.in.css', 'utf8')
-  let output = fs.readFileSync('./test/postcss.nested.out.css', 'utf8')
-  await nestedRun(input, output)
-})
+  await run('postcss.nested.in', 'postcss.nested.out', {}, [nested])
+});
 
 it('postcss media minmax -> nested', async () => {
-  let input = fs.readFileSync('./test/postcss.media.minmax.in.css', 'utf8')
-  let output = fs.readFileSync('./test/postcss.media.minmax.out.css', 'utf8')
-  await mediaMinmaxBeforeNestedRun(input, output)
-})
+  await run('postcss.media.minmax.in', 'postcss.media.minmax.out', {}, [autoprefixer, flexbugsFixes, mediaMinMax, nested])
+});
 
 it('postcss nested -> media minmax', async () => {
-  let input = fs.readFileSync('./test/postcss.media.minmax.in.css', 'utf8')
-  let output = fs.readFileSync('./test/postcss.media.minmax.out.css', 'utf8')
-  await mediaMinmaxAfterNestedRun(input, output)
-})
+  await run('postcss.media.minmax.in', 'postcss.media.minmax.out', {}, [autoprefixer, flexbugsFixes, nested, mediaMinMax])
+});
 
 it('only top level', async () => {
-  let input = fs.readFileSync('./test/only-top-level.in.css', 'utf8')
-  let output = fs.readFileSync('./test/only-top-level.out.css', 'utf8')
-  await run(input, output, { onlyTopLevel: true })
-})
+  await run('only-top-level.in', 'only-top-level.out', { onlyTopLevel: true })
+});

--- a/index.test.js
+++ b/index.test.js
@@ -50,6 +50,14 @@ it('[df] mixed #1', async () => {
   await run('mixed-desktop.in', 'mixed-desktop.out', { sort: 'desktop-first' });
 });
 
+it('use custom sort function', async () => {
+  await run('custom-sort.in', 'custom-sort.out', { sort: (a, b) => a.length < b.length }, []);
+});
+
+it('sort recursively', async () => {
+  await run('recursive-sort.in', 'recursive-sort.out', { recursive: true }, []);
+});
+
 it('[mf] configuration(mixed #1): unitlessMqAlwaysFirst: FALSE', async () => {
   const options = {
     configuration: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "sort-css-media-queries": "2.2.0"
       },
       "devDependencies": {
+        "@types/jest": "^29.5.2",
         "autoprefixer": "^10.4.0",
         "eslint": "^8.3.0",
         "eslint-ci": "^1.0.0",
@@ -821,6 +822,27 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.5.0.tgz",
+      "integrity": "sha512-fmKzsidoXQT2KwnrwE0SQq3uj8Z763vzR8LnLBwC2qYWEFpjX8daRsk6rHUM1QvNlEW/UJXNXm59ztmJJWs2Mg==",
+      "dev": true,
+      "dependencies": {
+        "jest-get-type": "^29.4.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils/node_modules/jest-get-type": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
+      "integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jest/fake-timers": {
       "version": "27.3.1",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.3.1.tgz",
@@ -894,6 +916,18 @@
         "node-notifier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
+      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.25.16"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/source-map": {
@@ -1017,6 +1051,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.25.24",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
+      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==",
+      "dev": true
+    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -1117,6 +1157,175 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.2.tgz",
+      "integrity": "sha512-mSoZVJF5YzGVCk+FsDxzDuH7s+SCkzrgKZzf0Z0T2WudhBUPoF6ktoTPC4R0ZoCPCV5xUvuU6ias5NvxcBcMMg==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/types": {
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
+      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.4.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@types/yargs": {
+      "version": "17.0.24",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/diff-sequences": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
+      "integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/expect": {
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.5.0.tgz",
+      "integrity": "sha512-yM7xqUrCO2JdpFo4XpM82t+PJBFybdqoQuJLDGeDX2ij8NZzqRHyu3Hp188/JX7SWqud+7t4MUdvcgGBICMHZg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/expect-utils": "^29.5.0",
+        "jest-get-type": "^29.4.3",
+        "jest-matcher-utils": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-util": "^29.5.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-diff": {
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.5.0.tgz",
+      "integrity": "sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.4.3",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.5.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-get-type": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
+      "integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.5.0.tgz",
+      "integrity": "sha512-lecRtgm/rjIK0CQ7LPQwzCs2VwW6WAahA55YBuI+xqmhm7LAaxokSB8C97yJeYyT+HvQkH741StzpU41wohhWw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.5.0",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.5.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-message-util": {
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.5.0.tgz",
+      "integrity": "sha512-Kijeg9Dag6CKtIDA7O21zNTACqD5MD/8HfIV8pdD94vFyFuer52SigdC3IQMhab3vACxXMiFk+yMHNdbqtyTGA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.5.0",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.5.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-util": {
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.5.0.tgz",
+      "integrity": "sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
+      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.4.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
@@ -2840,9 +3049,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
     "node_modules/has": {
@@ -6353,6 +6562,23 @@
         "jest-mock": "^27.3.0"
       }
     },
+    "@jest/expect-utils": {
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.5.0.tgz",
+      "integrity": "sha512-fmKzsidoXQT2KwnrwE0SQq3uj8Z763vzR8LnLBwC2qYWEFpjX8daRsk6rHUM1QvNlEW/UJXNXm59ztmJJWs2Mg==",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^29.4.3"
+      },
+      "dependencies": {
+        "jest-get-type": {
+          "version": "29.4.3",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
+          "integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
+          "dev": true
+        }
+      }
+    },
     "@jest/fake-timers": {
       "version": "27.3.1",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.3.1.tgz",
@@ -6409,6 +6635,15 @@
         "string-length": "^4.0.1",
         "terminal-link": "^2.0.0",
         "v8-to-istanbul": "^8.1.0"
+      }
+    },
+    "@jest/schemas": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
+      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
+      "dev": true,
+      "requires": {
+        "@sinclair/typebox": "^0.25.16"
       }
     },
     "@jest/source-map": {
@@ -6508,6 +6743,12 @@
         "fastq": "^1.6.0"
       }
     },
+    "@sinclair/typebox": {
+      "version": "0.25.24",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
+      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==",
+      "dev": true
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -6604,6 +6845,144 @@
       "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "29.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.2.tgz",
+      "integrity": "sha512-mSoZVJF5YzGVCk+FsDxzDuH7s+SCkzrgKZzf0Z0T2WudhBUPoF6ktoTPC4R0ZoCPCV5xUvuU6ias5NvxcBcMMg==",
+      "dev": true,
+      "requires": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "29.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
+          "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^29.4.3",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^17.0.8",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "17.0.24",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+          "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "29.4.3",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
+          "integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
+          "dev": true
+        },
+        "expect": {
+          "version": "29.5.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-29.5.0.tgz",
+          "integrity": "sha512-yM7xqUrCO2JdpFo4XpM82t+PJBFybdqoQuJLDGeDX2ij8NZzqRHyu3Hp188/JX7SWqud+7t4MUdvcgGBICMHZg==",
+          "dev": true,
+          "requires": {
+            "@jest/expect-utils": "^29.5.0",
+            "jest-get-type": "^29.4.3",
+            "jest-matcher-utils": "^29.5.0",
+            "jest-message-util": "^29.5.0",
+            "jest-util": "^29.5.0"
+          }
+        },
+        "jest-diff": {
+          "version": "29.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.5.0.tgz",
+          "integrity": "sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^29.4.3",
+            "jest-get-type": "^29.4.3",
+            "pretty-format": "^29.5.0"
+          }
+        },
+        "jest-get-type": {
+          "version": "29.4.3",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
+          "integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
+          "dev": true
+        },
+        "jest-matcher-utils": {
+          "version": "29.5.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.5.0.tgz",
+          "integrity": "sha512-lecRtgm/rjIK0CQ7LPQwzCs2VwW6WAahA55YBuI+xqmhm7LAaxokSB8C97yJeYyT+HvQkH741StzpU41wohhWw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^29.5.0",
+            "jest-get-type": "^29.4.3",
+            "pretty-format": "^29.5.0"
+          }
+        },
+        "jest-message-util": {
+          "version": "29.5.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.5.0.tgz",
+          "integrity": "sha512-Kijeg9Dag6CKtIDA7O21zNTACqD5MD/8HfIV8pdD94vFyFuer52SigdC3IQMhab3vACxXMiFk+yMHNdbqtyTGA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@jest/types": "^29.5.0",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.9",
+            "micromatch": "^4.0.4",
+            "pretty-format": "^29.5.0",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.3"
+          }
+        },
+        "jest-util": {
+          "version": "29.5.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.5.0.tgz",
+          "integrity": "sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^29.5.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.9",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "pretty-format": {
+          "version": "29.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
+          "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^29.4.3",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^18.0.0"
+          }
+        },
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+          "dev": true
+        }
       }
     },
     "@types/json-schema": {
@@ -7864,9 +8243,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
     "has": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "sort-css-media-queries": "2.2.0"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.2",
     "autoprefixer": "^10.4.0",
     "eslint": "^8.3.0",
     "eslint-ci": "^1.0.0",

--- a/test/custom-sort.in.css
+++ b/test/custom-sort.in.css
@@ -1,0 +1,24 @@
+@media screen and (max-width: 640px) {
+  .s1m { color: #ccc }
+}
+@media tv {
+  .s1m { color: #ccc }
+}
+@media screen and (max-width: 980px) {
+  .s1m { color: #ccc }
+}
+@media screen and (max-width: 768px) {
+  .s1m { color: #ccc }
+}
+@media screen and (min-width: 640px) {
+  .s1m { color: #ccc }
+}
+@media screen and (min-width: 1280px) {
+  .s1m { color: #ccc }
+}
+@media print {
+  .s1m { color: #ccc }
+}
+@media screen and (max-width: 1280px) {
+  .s1m { color: #ccc }
+}

--- a/test/custom-sort.out.css
+++ b/test/custom-sort.out.css
@@ -1,0 +1,16 @@
+@media screen and (max-width: 640px) {
+  .s1m { color: #ccc } }
+@media tv {
+  .s1m { color: #ccc } }
+@media screen and (max-width: 980px) {
+  .s1m { color: #ccc } }
+@media screen and (max-width: 768px) {
+  .s1m { color: #ccc } }
+@media screen and (min-width: 640px) {
+  .s1m { color: #ccc } }
+@media screen and (min-width: 1280px) {
+  .s1m { color: #ccc } }
+@media print {
+  .s1m { color: #ccc } }
+@media screen and (max-width: 1280px) {
+  .s1m { color: #ccc } }

--- a/test/recursive-sort.in.css
+++ b/test/recursive-sort.in.css
@@ -1,0 +1,39 @@
+@media (min-width: 700px) {
+  .a {
+    color: #00FF00;
+  }
+}
+
+@media print{
+  @media (min-width: 250px) {
+    .b {
+      color: #FF0000;
+    }
+  }
+
+  @media (min-width: 700px) {
+    .b {
+      color: #FF0000;
+    }
+  }
+
+  @media (min-width: 150px) {
+    .b {
+      color: #FF0000;
+    }
+  }
+}
+
+@media print {
+  @media (min-width: 700px) {
+    .b {
+      color: #FF0000;
+    }
+  }
+}
+
+@media (width >= 400px) {
+  .a {
+    color: #00FF00;
+  }
+}

--- a/test/recursive-sort.out.css
+++ b/test/recursive-sort.out.css
@@ -1,0 +1,30 @@
+@media (width >= 400px) {
+  .a {
+    color: #00FF00;
+  }
+}
+@media (min-width: 700px) {
+  .a {
+    color: #00FF00;
+  }
+}
+@media print {
+  @media (min-width: 150px) {
+    .b {
+      color: #FF0000;
+    }
+  }
+  @media (min-width: 250px) {
+    .b {
+      color: #FF0000;
+    }
+  }
+  @media (min-width: 700px) {
+    .b {
+      color: #FF0000;
+    }
+    .b {
+      color: #FF0000;
+    }
+  }
+}


### PR DESCRIPTION
Following the disscusions on https://github.com/yunusga/postcss-sort-media-queries/issues/38 and  https://github.com/OlehDutchenko/sort-css-media-queries/issues/24 I decided to implement some sort of feature to adress it. Feel free to comment and let me know what is needed for this to be merged. The code is not complete (missing tests coverage) but it works. I wanted to open the PR because I was also working on an aditional feature to nest the media queries conditionally.

In implementing the changes mainly because I'm trying to ship the smallest possible css using stable enough features. Merging the atRules and media queries has reduced 30% of the file size already and I'm pushing for another significant reduction after I'm able to implement the media querie nesting. I'm having problems rn but I've aready ran out of time to figure it out, so probably next week I'll work on it.

Again I'll await your comments.