### PR TITLE
Add package types entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "type": "module",
   "main": "src/index.js",
   "module": "src/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- add a top-level types field pointing at the shipped dist/index.d.ts declarations
- keep it aligned with the existing exports.types entry

## Verification
- installed postcss-sort-media-queries@6.6.1 in a clean temp project
- confirmed TypeScript Node10 module resolution cannot find declarations before the metadata fix
- patched the installed package metadata to ./dist/index.d.ts and confirmed tsc resolves the module